### PR TITLE
Add UnescapeJson functionality to early NiFi

### DIFF
--- a/JSON/UnescapeJson/example/in/flowfile.json
+++ b/JSON/UnescapeJson/example/in/flowfile.json
@@ -1,0 +1,1 @@
+[{"name1":"KIM Ltd.","forma":"[{\"key0\":\"val0\",\"key1\":\"val1\",\"key2\":\"val2\"}]","name2":""}]

--- a/JSON/UnescapeJson/example/out/flowfile.json
+++ b/JSON/UnescapeJson/example/out/flowfile.json
@@ -1,0 +1,1 @@
+[{"name1":"KIM Ltd.","forma":[{"key0":"val0","key1":"val1","key2":"val2"}],"name2":""}]

--- a/JSON/UnescapeJson/readme.md
+++ b/JSON/UnescapeJson/readme.md
@@ -1,0 +1,69 @@
+(EN) Unescape all inner JSON strings in FlowFile
+==============================================
+Unescape JSON from all inner strings. 
+The script is implemented for early versions of NiFi, where the unescapeJson function is missing.
+
+In FlowFile Example:
+
+`
+[
+  {
+    "name1": "KIM Ltd.",
+    "forma": "[{\"key0\":\"val0\",\"key1\":\"val1\",\"key2\":\"val2\"}]",
+    "name2": ""
+  }
+]
+`
+
+Results of Script:
+
+`
+[
+	{
+		"name1": "Kim Ltd",
+		"forma": [
+			{
+				"key0": "val0",
+				"key1": "val1",
+				"key2": "val2"
+			}
+		],
+		"name2": ""
+	}
+]
+`
+
+(RU) Достает все вложенные JSON из экранированных строк. 
+===================================================================
+Скрипт реализован для ранних версий NiFi, где функция unescapeJson отсутствует.
+
+*Пример входящего файла*
+
+`
+[
+  {
+    "name1": "KIM Ltd.",
+    "forma": "[{\"key0\":\"val0\",\"key1\":\"val1\",\"key2\":\"val2\"}]",
+    "name2": ""
+  }
+]
+`
+
+
+*Результаты для скрипта по данному файлу*
+
+`
+[
+	{
+		"name1": "Kim Ltd",
+		"forma": [
+			{
+				"key0": "val0",
+				"key1": "val1",
+				"key2": "val2"
+			}
+		],
+		"name2": ""
+	}
+]
+`

--- a/JSON/UnescapeJson/script.groovy
+++ b/JSON/UnescapeJson/script.groovy
@@ -1,0 +1,72 @@
+import groovy.json.JsonGenerator
+import groovy.json.JsonOutput
+import groovy.json.JsonParserType
+import groovy.json.JsonSlurper
+
+import org.apache.commons.io.IOUtils
+import org.apache.nifi.processor.io.StreamCallback
+
+import java.nio.charset.StandardCharsets
+
+
+class DeepJson {
+
+    static def jsonSlurper = new JsonSlurper().setType(JsonParserType.CHARACTER_SOURCE)
+
+    static Object findDeep(Map map, Object key) {
+        map.get(key) ?: map.findResult { k, v -> if (v in Map) findDeep(v, key) }
+    }
+
+    static Object convertString(String s) {
+        try {
+            def js = jsonSlurper.parseText(s)
+            if (js in Map) {
+                convertMap(js)
+            } else if (js in ArrayList) {
+                convertArray(js)
+            } else s
+        } catch (ignored) {
+            s
+        }
+    }
+
+    static Map convertMap(Map m) {
+        m.each { it.value = convert(it.value) }
+    }
+
+    static ArrayList convertArray(ArrayList a) {
+        a.collect({convert(it)})
+        //a.collect({if (it in Map) convert(it) else it} ) // - replace line above if you want to skip array of string converting
+    }
+
+    static Object convert(Object o) {
+        if (o in Map) {
+            convertMap(o)
+        } else if (o in ArrayList) {
+            convertArray(o)
+        } else if (o in String) {
+            convertString(o)
+        } else
+            o
+    }
+
+    static String expandJsonStrings(String s) {
+        def object = jsonSlurper.parseText(s)
+        new JsonGenerator.Options().disableUnicodeEscaping().build().toJson(convert(object))
+    }
+}
+
+
+def flowFile = session.get();
+if (flowFile == null) {
+    return;
+}
+
+flowFile = session.write(
+        flowFile,
+        { inputStream, outputStream ->
+            def content = IOUtils.toString(inputStream, StandardCharsets.UTF_8)
+            outputStream.write(DeepJson.expandJsonStrings(content).getBytes(StandardCharsets.UTF_8))
+        } as StreamCallback
+)
+session.transfer(flowFile, REL_SUCCESS)


### PR DESCRIPTION
Unescape JSON from all inner strings. 
The script is implemented for early versions of NiFi, where the unescapeJson function is missing.
